### PR TITLE
Don't ignore the test `testSuccessfulSignupWithLocalPhoneNumber`

### DIFF
--- a/app/src/androidTest/java/com/reach5/identity/sdk/demo/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/reach5/identity/sdk/demo/MainActivityTest.kt
@@ -18,9 +18,13 @@ import java.lang.Error
 import java.lang.Exception
 import java.lang.Thread.sleep
 
+/**
+ * These tests use an account with:
+ * - the SMS feature enabled
+ * - the country set to "France"
+ */
 @RunWith(AndroidJUnit4::class)
 class MainActivityTest {
-    // The SMS feature is enabled on this account
     private val dotenv = dotenv {
         directory = "/assets"
         filename = "env"
@@ -170,7 +174,6 @@ class MainActivityTest {
         // TODO: check that the profile has received a verification SMS
     }
 
-    @Ignore
     @Test
     fun testSuccessfulSignupWithLocalPhoneNumber() {
         val client = instantiateReachFiveClient()


### PR DESCRIPTION
The `testSuccessfulSignupWithLocalPhoneNumber` test needed that we set the account's country to _France_.