### PR TITLE
Rename the `open_id` scope into `openid`

### DIFF
--- a/app/src/androidTest/java/com/reach5/identity/sdk/demo/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/reach5/identity/sdk/demo/MainActivityTest.kt
@@ -34,6 +34,7 @@ class MainActivityTest {
 
     private val TEST_SHOULD_NOT_FAIL = "This test should not have failed because the data are correct."
     private val TEST_SHOULD_FAIL_SCOPE_MISSING = "This test should have failed because the 'full_write' scope is missing."
+    private val NO_ID_TOKEN = "No id_token returned, verify that you have the `openid` scope configured in your API Client Settings."
 
     @get:Rule
     val activityRule = ActivityTestRule(MainActivity::class.java)
@@ -228,7 +229,7 @@ class MainActivityTest {
             ),
             listOf(),
             {},
-            { error -> assertEquals(error.message, "No id_token returned, verify if you have the open_id scope configured into your API Client Settings") }
+            { error -> assertEquals(error.message, NO_ID_TOKEN) }
         )
 
         // TODO: replace the `sleep` method by a callback mock
@@ -370,7 +371,7 @@ class MainActivityTest {
                     password,
                     listOf(),
                     {},
-                    { error -> assertEquals(error.message, "No id_token returned, verify if you have the open_id scope configured into your API Client Settings") }
+                    { error -> assertEquals(error.message, NO_ID_TOKEN) }
                 )
             },
             failure = { fail(TEST_SHOULD_NOT_FAIL) }

--- a/sdk-core/src/main/java/com/reach5/identity/sdk/core/models/AuthTokenResponse.kt
+++ b/sdk-core/src/main/java/com/reach5/identity/sdk/core/models/AuthTokenResponse.kt
@@ -58,7 +58,7 @@ data class AuthTokenResponse(
                 Result.error(ReachFiveError.from("No access_token returned"))
             }
         } else {
-            return Result.error(ReachFiveError.from("No id_token returned, verify if you have the open_id scope configured into your API Client Settings"))
+            return Result.error(ReachFiveError.from("No id_token returned, verify that you have the `openid` scope configured in your API Client Settings."))
         }
     }
 


### PR DESCRIPTION
I have renamed the `open_id` scope into `openid` in the error messages.