### PR TITLE
Implement the authentication flow with code in the WebViewProvider

### DIFF
--- a/sdk-core/src/main/java/com/reach5/identity/sdk/core/ReachFive.kt
+++ b/sdk-core/src/main/java/com/reach5/identity/sdk/core/ReachFive.kt
@@ -3,7 +3,8 @@ package com.reach5.identity.sdk.core
 import android.app.Activity
 import android.content.Intent
 import android.util.Log
-import com.reach5.identity.sdk.core.api.*
+import com.reach5.identity.sdk.core.api.ReachFiveApi
+import com.reach5.identity.sdk.core.api.ReachFiveApiCallback
 import com.reach5.identity.sdk.core.models.*
 import com.reach5.identity.sdk.core.models.UpdatePasswordRequest.Companion.enrichWithClientId
 import com.reach5.identity.sdk.core.utils.Failure
@@ -223,17 +224,11 @@ class ReachFive(val activity: Activity, val sdkConfig: SdkConfig, val providersC
     }
 
     fun logoutWithProviders(callback: () -> Unit) {
-        providers.forEach {
-            it.logout()
-        }.also {
-            callback()
-        }
+        providers.forEach { it.logout() }.also { callback() }
     }
 
     fun onStop() {
-        providers.forEach {
-            it.onStop()
-        }
+        providers.forEach { it.onStop() }
     }
 
     private fun formatAuthorization(authToken: AuthToken): String {

--- a/sdk-core/src/main/java/com/reach5/identity/sdk/core/api/ReachFiveApi.kt
+++ b/sdk-core/src/main/java/com/reach5/identity/sdk/core/api/ReachFiveApi.kt
@@ -2,17 +2,16 @@ package com.reach5.identity.sdk.core.api
 
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
+import com.reach5.identity.sdk.core.models.*
 import com.reach5.identity.sdk.core.utils.Failure
 import com.reach5.identity.sdk.core.utils.Success
-import com.reach5.identity.sdk.core.models.*
 import com.reach5.identity.sdk.core.utils.SuccessWithNoContent
 import retrofit2.Call
 import retrofit2.Callback
+import retrofit2.Response
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
-import retrofit2.Response
 import retrofit2.http.*
-import java.lang.Exception
 
 
 interface ReachFiveApi {
@@ -27,6 +26,9 @@ interface ReachFiveApi {
 
     @POST("/oauth/token")
     fun loginWithPassword(@Body loginRequest: LoginRequest, @QueryMap options: Map<String, String>): Call<AuthTokenResponse>
+
+    @POST("/oauth/token")
+    fun authenticateWithCode(@Body authCodeRequest: AuthCodeRequest, @QueryMap options: Map<String, String>): Call<AuthTokenResponse>
 
     @GET("/identity/v1/logout")
     fun logout(@QueryMap options: Map<String, String>): Call<Unit>

--- a/sdk-core/src/main/java/com/reach5/identity/sdk/core/models/AuthCodeRequest.kt
+++ b/sdk-core/src/main/java/com/reach5/identity/sdk/core/models/AuthCodeRequest.kt
@@ -1,0 +1,16 @@
+package com.reach5.identity.sdk.core.models
+
+import android.os.Parcelable
+import com.google.gson.annotations.SerializedName
+import kotlinx.android.parcel.Parcelize
+
+@Parcelize
+data class AuthCodeRequest(
+    @SerializedName("client_id")
+    val clientId: String,
+    val code: String,
+    @SerializedName("grant_type")
+    val grantType: String,
+    @SerializedName("redirect_uri")
+    val redirectUri: String
+) : Parcelable

--- a/sdk-core/src/main/java/com/reach5/identity/sdk/core/models/AuthTokenResponse.kt
+++ b/sdk-core/src/main/java/com/reach5/identity/sdk/core/models/AuthTokenResponse.kt
@@ -71,19 +71,4 @@ data class AuthTokenResponse(
             }
         }
     }
-
-    companion object {
-        @JvmStatic
-        fun fromQueryString(params: Map<String, String>): AuthTokenResponse {
-            return AuthTokenResponse(
-                idToken = params["id_token"],
-                accessToken = params["access_token"],
-                expiresIn = params["expires_in"]?.toIntOrNull(),
-                tokenType = params["token_type"],
-                error = params["error"],
-                errorDescription = params["error_description"],
-                code = null
-            )
-        }
-    }
 }

--- a/sdk-webview/src/main/java/com/reach5/identity/sdk/webview/WebViewProvider.kt
+++ b/sdk-webview/src/main/java/com/reach5/identity/sdk/webview/WebViewProvider.kt
@@ -63,7 +63,7 @@ class ConfiguredWebViewProvider(
                 .authenticateWithCode(authCodeRequest, SdkInfos.getQueries())
                 .enqueue(ReachFiveApiCallback(success = { it.toAuthToken().fold(success, failure) }, failure = failure))
         } else {
-            failure(ReachFiveError.from("No authentication code into activity result"))
+            failure(ReachFiveError.from("No authorization code into activity result"))
         }
     }
 

--- a/sdk-webview/src/main/java/com/reach5/identity/sdk/webview/WebViewProvider.kt
+++ b/sdk-webview/src/main/java/com/reach5/identity/sdk/webview/WebViewProvider.kt
@@ -1,14 +1,14 @@
 package com.reach5.identity.sdk.webview
 
 import android.app.Activity
-import android.content.Context
 import android.content.Intent
-import com.reach5.identity.sdk.core.utils.Failure
 import com.reach5.identity.sdk.core.Provider
 import com.reach5.identity.sdk.core.ProviderCreator
-import com.reach5.identity.sdk.core.utils.Success
 import com.reach5.identity.sdk.core.api.ReachFiveApi
+import com.reach5.identity.sdk.core.api.ReachFiveApiCallback
 import com.reach5.identity.sdk.core.models.*
+import com.reach5.identity.sdk.core.utils.Failure
+import com.reach5.identity.sdk.core.utils.Success
 
 class WebViewProvider : ProviderCreator {
     override val name: String = "webview"
@@ -19,13 +19,14 @@ class WebViewProvider : ProviderCreator {
         reachFiveApi: ReachFiveApi,
         activity: Activity
     ): Provider {
-        return ConfiguredWebViewProvider(providerConfig, sdkConfig)
+        return ConfiguredWebViewProvider(providerConfig, sdkConfig, reachFiveApi)
     }
 }
 
 class ConfiguredWebViewProvider(
     private val providerConfig: ProviderConfig,
-    private val sdkConfig: SdkConfig
+    private val sdkConfig: SdkConfig,
+    private val reachFiveApi: ReachFiveApi
 ) : Provider {
 
     override val name: String = providerConfig.provider
@@ -33,7 +34,7 @@ class ConfiguredWebViewProvider(
 
     companion object {
         const val BUNDLE_ID = "BUNDLE_REACH_FIVE"
-        const val OpenIdTokenResponse = "AuthTokenResponse"
+        const val AuthCode = "code"
         const val RequestCode = 52558
         const val RESULT_INTENT_ERROR = "RESULT_INTENT_ERROR"
     }
@@ -55,11 +56,14 @@ class ConfiguredWebViewProvider(
         success: Success<AuthToken>,
         failure: Failure<ReachFiveError>
     ) {
-        val openIdTokenResponse = data?.getParcelableExtra<AuthTokenResponse>(OpenIdTokenResponse)
-        return if (openIdTokenResponse != null) {
-            openIdTokenResponse.toAuthToken().fold(success, failure)
+        val authCode = data?.getStringExtra(AuthCode)
+        return if (authCode != null) {
+            val authCodeRequest = AuthCodeRequest(sdkConfig.clientId, authCode, "authorization_code", "reachfive://callback")
+            reachFiveApi
+                .authenticateWithCode(authCodeRequest, SdkInfos.getQueries())
+                .enqueue(ReachFiveApiCallback(success = { it.toAuthToken().fold(success, failure) }, failure = failure))
         } else {
-            failure(ReachFiveError.from("No token into activity result"))
+            failure(ReachFiveError.from("No authentication code into activity result"))
         }
     }
 

--- a/sdk-webview/src/main/java/com/reach5/identity/sdk/webview/WebViewProvider.kt
+++ b/sdk-webview/src/main/java/com/reach5/identity/sdk/webview/WebViewProvider.kt
@@ -63,7 +63,7 @@ class ConfiguredWebViewProvider(
                 .authenticateWithCode(authCodeRequest, SdkInfos.getQueries())
                 .enqueue(ReachFiveApiCallback(success = { it.toAuthToken().fold(success, failure) }, failure = failure))
         } else {
-            failure(ReachFiveError.from("No authorization code into activity result"))
+            failure(ReachFiveError.from("No authorization code found in activity result"))
         }
     }
 

--- a/sdk-webview/src/main/java/com/reach5/identity/sdk/webview/WebViewProvider.kt
+++ b/sdk-webview/src/main/java/com/reach5/identity/sdk/webview/WebViewProvider.kt
@@ -34,7 +34,7 @@ class ConfiguredWebViewProvider(
 
     companion object {
         const val BUNDLE_ID = "BUNDLE_REACH_FIVE"
-        const val AuthCode = "code"
+        const val AuthCode = "AuthCode"
         const val RequestCode = 52558
         const val RESULT_INTENT_ERROR = "RESULT_INTENT_ERROR"
     }

--- a/sdk-webview/src/main/java/com/reach5/identity/sdk/webview/WebViewProviderConfig.kt
+++ b/sdk-webview/src/main/java/com/reach5/identity/sdk/webview/WebViewProviderConfig.kt
@@ -20,7 +20,7 @@ internal data class WebViewProviderConfig(
             "provider" to providerConfig.provider,
             "origin" to origin,
             "redirect_uri" to "reachfive://callback",
-            "response_type" to "token",
+            "response_type" to "code",
             "scope" to scope.joinToString(" ")
         ) + SdkInfos.getQueries()
         val query = params.entries.joinToString("&") { (key, value) ->


### PR DESCRIPTION
**Asana task**: https://app.asana.com/0/1111569008372652/871746397519508

Initially, the WebViewProvider called the implicit authentication flow. I've replaced it by the authentication flow with code since it's more secure for a mobile application.

To test it, remove the native SDK providers (Facebook & Google) in the client's initialization (in the `MainActivity.kt` file):
```
val providersCreators = listOf(WebViewProvider())
```

 and run the application. Click on the _facebook_ button. You'll be asked to enter your Facebook credentials and to accept the consents. In the end, you'll receive an access token.
