### PR TITLE
Call the authorization code flow with PKCE

### DIFF
--- a/sdk-core/src/main/java/com/reach5/identity/sdk/core/models/AuthCodeRequest.kt
+++ b/sdk-core/src/main/java/com/reach5/identity/sdk/core/models/AuthCodeRequest.kt
@@ -12,5 +12,7 @@ data class AuthCodeRequest(
     @SerializedName("grant_type")
     val grantType: String,
     @SerializedName("redirect_uri")
-    val redirectUri: String
+    val redirectUri: String,
+    @SerializedName("code_verifier")
+    val codeVerifier: String
 ) : Parcelable

--- a/sdk-core/src/main/java/com/reach5/identity/sdk/core/utils/Pkce.kt
+++ b/sdk-core/src/main/java/com/reach5/identity/sdk/core/utils/Pkce.kt
@@ -14,39 +14,39 @@ class Pkce(val codeVerifier: String) : Parcelable {
     val codeChallenge: String
     @IgnoredOnParcel
     val codeChallengeMethod: String
-
+    
     init {
         this.codeChallenge = generateCodeChallenge(codeVerifier)
         this.codeChallengeMethod = "S256"
     }
 
-    override fun toString(): String {
-        return "code_verifier=$codeVerifier, code_challenge=$codeChallenge, code_challenge_method=$codeChallengeMethod"
-    }
+    override fun toString(): String =
+        "code_verifier=$codeVerifier, code_challenge=$codeChallenge, code_challenge_method=$codeChallengeMethod"
 
     companion object {
-        fun generate(): Pkce {
-            val codeVerifier= generateCodeVerifier()
-            return Pkce(codeVerifier)
-        }
+        private const val BASE64_FLAGS = Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING
+        
+        fun generate(): Pkce = Pkce(generateCodeVerifier())
 
-        private fun generateCodeVerifier(): String {
-            val secureRandom = SecureRandom()
-
-            val code = ByteArray(32)
-            secureRandom.nextBytes(code)
-
-            return Base64.encodeToString(code, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
-        }
+        private fun generateCodeVerifier(): String =
+            SecureRandom()
+                .let { secureRandom ->
+                    ByteArray(32).also { secureRandom.nextBytes(it) }
+                }
+                .let { code ->
+                    Base64.encodeToString(code, BASE64_FLAGS)
+                }
     }
 
-    private fun generateCodeChallenge(codeVerifier: String): String {
-        val bytes = codeVerifier.toByteArray(UTF_8)
-
-        val messageDigest = MessageDigest.getInstance("SHA-256")
-        messageDigest.update(bytes, 0, bytes.size)
-        val digest = messageDigest.digest()
-
-        return Base64.encodeToString(digest, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
-    }
+    private fun generateCodeChallenge(codeVerifier: String): String =
+        codeVerifier
+            .toByteArray(UTF_8)
+            .let { bytes ->
+                MessageDigest.getInstance("SHA-256")
+                    .also { it.update(bytes, 0, bytes.size) }
+                    .digest()
+            }
+            .let{ digest ->
+                Base64.encodeToString(digest, BASE64_FLAGS)
+            }
 }

--- a/sdk-core/src/main/java/com/reach5/identity/sdk/core/utils/Pkce.kt
+++ b/sdk-core/src/main/java/com/reach5/identity/sdk/core/utils/Pkce.kt
@@ -1,0 +1,52 @@
+package com.reach5.identity.sdk.core.utils
+
+import android.os.Parcelable
+import android.util.Base64
+import kotlinx.android.parcel.IgnoredOnParcel
+import kotlinx.android.parcel.Parcelize
+import java.security.MessageDigest
+import java.security.SecureRandom
+import kotlin.text.Charsets.UTF_8
+
+@Parcelize
+class Pkce(val codeVerifier: String) : Parcelable {
+    @IgnoredOnParcel
+    val codeChallenge: String
+    @IgnoredOnParcel
+    val codeChallengeMethod: String
+
+    init {
+        this.codeChallenge = generateCodeChallenge(codeVerifier)
+        this.codeChallengeMethod = "S256"
+    }
+
+    override fun toString(): String {
+        return "code_verifier=$codeVerifier, code_challenge=$codeChallenge, code_challenge_method=$codeChallengeMethod"
+    }
+
+    companion object {
+        fun generate(): Pkce {
+            val codeVerifier= generateCodeVerifier()
+            return Pkce(codeVerifier)
+        }
+
+        private fun generateCodeVerifier(): String {
+            val secureRandom = SecureRandom()
+
+            val code = ByteArray(32)
+            secureRandom.nextBytes(code)
+
+            return Base64.encodeToString(code, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
+        }
+    }
+
+    private fun generateCodeChallenge(codeVerifier: String): String {
+        val bytes = codeVerifier.toByteArray(UTF_8)
+
+        val messageDigest = MessageDigest.getInstance("SHA-256")
+        messageDigest.update(bytes, 0, bytes.size)
+        val digest = messageDigest.digest()
+
+        return Base64.encodeToString(digest, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
+    }
+}

--- a/sdk-webview/src/main/java/com/reach5/identity/sdk/webview/ReachFiveLoginActivity.kt
+++ b/sdk-webview/src/main/java/com/reach5/identity/sdk/webview/ReachFiveLoginActivity.kt
@@ -13,6 +13,7 @@ import android.view.View
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import com.reach5.identity.sdk.core.utils.Pkce
 import kotlinx.android.synthetic.main.reachfive_login_activity.*
 import java.util.regex.Pattern
 
@@ -32,7 +33,8 @@ class ReachFiveLoginActivity : Activity() {
 
         webview.webViewClient = ReachFiveWebViewClient()
 
-        val url = config.buildUrl()
+        val pkce = intent.getParcelableExtra<Pkce>(ConfiguredWebViewProvider.PKCE)
+        val url = config.buildUrl(pkce)
 
         Log.d(TAG, "ReachFiveLoginActivity onCreate : $url")
 
@@ -58,7 +60,6 @@ class ReachFiveLoginActivity : Activity() {
     }
 
     fun loginSuccess(authCode: String?) {
-        val intent = Intent()
         intent.putExtra(ConfiguredWebViewProvider.AuthCode, authCode)
         setResult(ConfiguredWebViewProvider.RequestCode, intent)
         finish()

--- a/sdk-webview/src/main/java/com/reach5/identity/sdk/webview/WebViewProviderConfig.kt
+++ b/sdk-webview/src/main/java/com/reach5/identity/sdk/webview/WebViewProviderConfig.kt
@@ -5,6 +5,7 @@ import android.os.Parcelable
 import com.reach5.identity.sdk.core.models.ProviderConfig
 import com.reach5.identity.sdk.core.models.SdkConfig
 import com.reach5.identity.sdk.core.models.SdkInfos
+import com.reach5.identity.sdk.core.utils.Pkce
 import java.net.URLEncoder
 
 internal data class WebViewProviderConfig(
@@ -13,7 +14,7 @@ internal data class WebViewProviderConfig(
     val origin: String
 ) : Parcelable {
 
-    fun buildUrl(): String {
+    fun buildUrl(pkce: Pkce): String {
         val scope = (providerConfig.scope ?: setOf()).plus("openid")
         val params = mapOf(
             "client_id" to sdkConfig.clientId,
@@ -21,7 +22,9 @@ internal data class WebViewProviderConfig(
             "origin" to origin,
             "redirect_uri" to "reachfive://callback",
             "response_type" to "code",
-            "scope" to scope.joinToString(" ")
+            "scope" to scope.joinToString(" "),
+            "code_challenge" to pkce.codeChallenge,
+            "code_challenge_method" to pkce.codeChallengeMethod
         ) + SdkInfos.getQueries()
         val query = params.entries.joinToString("&") { (key, value) ->
             "${URLEncoder.encode(key, "UTF-8")}=${URLEncoder.encode(value, "UTF-8")}"


### PR DESCRIPTION
**Asana ticket**: https://app.asana.com/0/1111569008372652/871746397519508

I've implemented the PKCE within the authorization code flow called when a user logs in with the `WebViewProvider`.

The PKCE is generated when the user clicks on the login button (in the example, one must click on the provider's name). It's then saved in the [`Intent`](https://developer.android.com/reference/android/content/Intent.html) object and is retrieved in the activity to build the authorize and access token API calls.