### PR TITLE
Release v4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v4.2.0 (22/07/2019)
+
+### Features
+
+- All the SDK core models are now serialized for an Android implementation.
+- The authorization flow with code and the PKCE are implemented for a login with the `WebViewProvider`.
+
 ## v4.1.0 (12/07/2019)
 
 ### Features

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext.kotlin_version = "1.3.30"
-    ext.lib_version = "4.1.0"
+    ext.lib_version = "4.2.0"
     ext.lib_group = "com.reach5.identity"
     ext.min_sdk_version = 19
     ext.target_sdk_version = 28


### PR DESCRIPTION
- Update the changelog.
- Bump the version to `4.2.0`.