### PR TITLE
Don't pass the `accessToken` in the `requestPasswordReset` method

### DIFF
--- a/app/src/androidTest/java/com/reach5/identity/sdk/demo/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/reach5/identity/sdk/demo/MainActivityTest.kt
@@ -668,10 +668,9 @@ class MainActivityTest {
         client.signup(
             profile,
             scope,
-            success = { authToken ->
+            success = {
                 client.requestPasswordReset(
-                    authToken,
-                    email = profile.email!!,
+                    email = "roxane@reach5.co",
                     successWithNoContent = {},
                     failure = { failWithReachFiveError(it) }
                 )
@@ -688,9 +687,8 @@ class MainActivityTest {
         client.signup(
             profile,
             scope,
-            success = { authToken ->
+            success = {
                 client.requestPasswordReset(
-                    authToken,
                     phoneNumber = profile.phoneNumber!!,
                     successWithNoContent = {},
                     failure = { failWithReachFiveError(it) }
@@ -708,9 +706,8 @@ class MainActivityTest {
         client.signup(
             profile,
             scope,
-            success = { authToken ->
+            success = {
                 client.requestPasswordReset(
-                    authToken,
                     email = null,
                     phoneNumber = null,
                     successWithNoContent = { fail("This test should have failed because neither the email or the phone number were provided.") },

--- a/sdk-core/src/main/java/com/reach5/identity/sdk/core/JavaReachFive.kt
+++ b/sdk-core/src/main/java/com/reach5/identity/sdk/core/JavaReachFive.kt
@@ -143,7 +143,6 @@ class JavaReachFive(activity: Activity, sdkConfig: SdkConfig, providersCreators:
     }
 
     fun requestPasswordReset(
-        authToken: AuthToken,
         email: String?,
         redirectUrl: String?,
         phoneNumber: String?,
@@ -151,7 +150,6 @@ class JavaReachFive(activity: Activity, sdkConfig: SdkConfig, providersCreators:
         failure: Callback<ReachFiveError>
     ) {
         return reach5.requestPasswordReset(
-            authToken,
             email,
             redirectUrl,
             phoneNumber,

--- a/sdk-core/src/main/java/com/reach5/identity/sdk/core/ReachFive.kt
+++ b/sdk-core/src/main/java/com/reach5/identity/sdk/core/ReachFive.kt
@@ -195,7 +195,6 @@ class ReachFive(val activity: Activity, val sdkConfig: SdkConfig, val providersC
     }
 
     fun requestPasswordReset(
-        authToken: AuthToken,
         email: String? = null,
         redirectUrl: String? = null,
         phoneNumber: String? = null,
@@ -204,7 +203,6 @@ class ReachFive(val activity: Activity, val sdkConfig: SdkConfig, val providersC
     ) {
         reachFiveApi
             .requestPasswordReset(
-                formatAuthorization(authToken),
                 RequestPasswordResetRequest(
                     sdkConfig.clientId,
                     email,

--- a/sdk-core/src/main/java/com/reach5/identity/sdk/core/api/ReachFiveApi.kt
+++ b/sdk-core/src/main/java/com/reach5/identity/sdk/core/api/ReachFiveApi.kt
@@ -76,7 +76,6 @@ interface ReachFiveApi {
 
     @POST("/identity/v1/forgot-password")
     fun requestPasswordReset(
-        @Header("Authorization") authorization: String,
         @Body requestPasswordResetRequest: RequestPasswordResetRequest,
         @QueryMap options: Map<String, String>
     ): Call<Unit>


### PR DESCRIPTION
I've removed the `accessToken` argument from the `requestPasswordReset` method since a user doesn't need to be logged in to request a password reset.