### PR TITLE
IdToken is now optional

### DIFF
--- a/app/src/main/java/com/reach5/identity/sdk/demo/JavaMainActivity.java
+++ b/app/src/main/java/com/reach5/identity/sdk/demo/JavaMainActivity.java
@@ -14,7 +14,7 @@ import com.reach5.identity.sdk.core.JavaReachFive;
 import com.reach5.identity.sdk.core.Provider;
 import com.reach5.identity.sdk.core.models.AuthToken;
 import com.reach5.identity.sdk.core.models.SdkConfig;
-import com.reach5.identity.sdk.core.models.User;
+import com.reach5.identity.sdk.core.models.OpenIdUser;
 import com.reach5.identity.sdk.core.models.requests.ProfileSignupRequest;
 import com.reach5.identity.sdk.google.GoogleProvider;
 import com.reach5.identity.sdk.webview.WebViewProvider;
@@ -102,7 +102,7 @@ public class JavaMainActivity extends AppCompatActivity {
     }
 
     private void handleLoginSuccess(AuthToken authToken) {
-        User user = authToken.getUser();
+        OpenIdUser user = authToken.getUser();
         Objects.requireNonNull(getSupportActionBar()).setTitle(user.getEmail());
         showToast("Login success " + authToken.getAccessToken());
     }

--- a/sdk-core/src/main/java/com/reach5/identity/sdk/core/models/AuthTokenResponse.kt
+++ b/sdk-core/src/main/java/com/reach5/identity/sdk/core/models/AuthTokenResponse.kt
@@ -15,7 +15,7 @@ data class AuthToken(
     val code: String?,
     val tokenType: String?,
     val expiresIn: Int?,
-    // The `user` field is optional because if the `openid` scope is not provided, the `idToken` is not returned
+    // The `user` field is optional because if the `openid` scope is not provided, the `user` is not retrieved
     val user: OpenIdUser? = null
 ) : Parcelable
 

--- a/sdk-core/src/main/java/com/reach5/identity/sdk/core/models/AuthTokenResponse.kt
+++ b/sdk-core/src/main/java/com/reach5/identity/sdk/core/models/AuthTokenResponse.kt
@@ -9,13 +9,14 @@ import kotlinx.android.parcel.Parcelize
 
 @Parcelize
 data class AuthToken(
-    val idToken: String,
+    // If the `openid` scope is not provided, the `idToken` is not returned
+    val idToken: String? = null,
     val accessToken: String,
     val code: String?,
     val tokenType: String?,
     val expiresIn: Int?,
     // The `user` field is optional because if the `openid` scope is not provided, the `idToken` is not returned
-    val user: User?
+    val user: OpenIdUser? = null
 ) : Parcelable
 
 @Parcelize
@@ -42,8 +43,8 @@ data class AuthTokenResponse(
     val errorDescription: String? = null
 ) : Parcelable {
     fun toAuthToken(): Result<AuthToken, ReachFiveError> {
-        if (idToken != null) {
-            return if (accessToken != null) {
+        return if (accessToken != null) {
+            if (idToken != null) {
                 getUser().map {
                     AuthToken(
                         idToken = idToken,
@@ -55,17 +56,24 @@ data class AuthTokenResponse(
                     )
                 }
             } else {
-                Result.error(ReachFiveError.from("No access_token returned"))
+                Result.of {
+                    AuthToken(
+                        accessToken = accessToken,
+                        code = code,
+                        tokenType = tokenType,
+                        expiresIn = expiresIn
+                    )
+                }
             }
         } else {
-            return Result.error(ReachFiveError.from("No id_token returned, verify that you have the `openid` scope configured in your API Client Settings."))
+            Result.error(ReachFiveError.from("No access_token returned"))
         }
     }
 
-    private fun getUser(): Result<User, ReachFiveError> {
+    private fun getUser(): Result<OpenIdUser, ReachFiveError> {
         return Result.of {
             if (idToken != null) {
-                Jwt.decode(idToken, User::class.java)
+                Jwt.decode(idToken, OpenIdUser::class.java)
             } else {
                 throw ReachFiveError.from("Invalid id_token")
             }

--- a/sdk-core/src/main/java/com/reach5/identity/sdk/core/models/OpenIdUser.kt
+++ b/sdk-core/src/main/java/com/reach5/identity/sdk/core/models/OpenIdUser.kt
@@ -5,13 +5,13 @@ import com.google.gson.annotations.SerializedName
 import kotlinx.android.parcel.Parcelize
 
 @Parcelize
-data class User(
+data class OpenIdUser(
     // Corresponds to the `sub` field in the JSON
     @SerializedName("sub")
     val id: String?,
+    val name: String?,
     @SerializedName("preferred_username")
     val preferredUsername: String?,
-    val name: String?,
     @SerializedName("given_name")
     val givenName: String?,
     @SerializedName("family_name")

--- a/sdk-core/src/main/java/com/reach5/identity/sdk/core/models/ProviderConfig.kt
+++ b/sdk-core/src/main/java/com/reach5/identity/sdk/core/models/ProviderConfig.kt
@@ -8,7 +8,7 @@ data class ProviderConfig(
     val provider: String,
     val clientId: String,
     val clientSecret: String?,
-    val scope: Set<String> = setOf()
+    val scope: Set<String> = emptySet()
 ) : Parcelable
 
 @Parcelize

--- a/sdk-core/src/main/java/com/reach5/identity/sdk/core/models/ProviderConfig.kt
+++ b/sdk-core/src/main/java/com/reach5/identity/sdk/core/models/ProviderConfig.kt
@@ -8,7 +8,7 @@ data class ProviderConfig(
     val provider: String,
     val clientId: String,
     val clientSecret: String?,
-    val scope: Set<String>?
+    val scope: Set<String> = setOf()
 ) : Parcelable
 
 @Parcelize

--- a/sdk-webview/src/main/java/com/reach5/identity/sdk/webview/WebViewProviderConfig.kt
+++ b/sdk-webview/src/main/java/com/reach5/identity/sdk/webview/WebViewProviderConfig.kt
@@ -15,7 +15,7 @@ internal data class WebViewProviderConfig(
 ) : Parcelable {
 
     fun buildUrl(pkce: Pkce): String {
-        val scope = (providerConfig.scope ?: setOf()).plus("openid")
+        val scope = (providerConfig.scope)
         val params = mapOf(
             "client_id" to sdkConfig.clientId,
             "provider" to providerConfig.provider,


### PR DESCRIPTION
**Asana task**: https://app.asana.com/0/1111569008372652/1132240385044223

- I have renamed the `User` data class into `OpenIdUser` to be ISO with the iOS SDK. **THIS IS A BREAKING CHANGE!**
- The `idToken` field is now optional in the `AuthToken` data class since login and signup can succeed without it. It must be the SDK developer who fully manages the scopes. 
- I've deleted the tests which check that an error is thrown when the `idToken` is not returned. 
- The `openid` scope is no longer provided by default to the `loginWithProvider` method through the `WebViewProvider`.