### PR TITLE
Add a test for get profile with missing scope

### DIFF
--- a/app/src/androidTest/java/com/reach5/identity/sdk/demo/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/reach5/identity/sdk/demo/MainActivityTest.kt
@@ -286,6 +286,32 @@ class MainActivityTest {
     }
 
     @Test
+    fun testFailedGetProfileWithMissingScopes() = clientTest { client ->
+        val theProfile = aProfile()
+        val scope = openId + email
+
+        client.signup(
+            theProfile,
+            scope,
+            success = { authToken ->
+                client.getProfile(
+                    authToken,
+                    { fetchedProfile ->
+                        // Since the `profile` scope is missing, the personal data is not returned
+                        assertNull(fetchedProfile.givenName)
+                        assertNull(fetchedProfile.familyName)
+                        assertNull(fetchedProfile.gender)
+
+                        assertEquals(theProfile.email, fetchedProfile.email)
+                    },
+                    { error -> failWithReachFiveError(error) }
+                )
+            },
+            failure = { failWithReachFiveError(it) }
+        )
+    }
+
+    @Test
     fun testFailedVerifyPhoneNumberWithWrongCode() = clientTest { client ->
         val profile = aProfile().copy(phoneNumber = aPhoneNumber())
         val incorrectVerificationCode = "500"


### PR DESCRIPTION
**Asana task**: https://app.asana.com/0/1111569008372652/1132240385044223

I've added a test to see what's the `getProfile` method response when the `profile` scope is not provided.