### PR TITLE
Delete the `authToken` argument from the `updatePassword`

### DIFF
--- a/app/src/androidTest/java/com/reach5/identity/sdk/demo/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/reach5/identity/sdk/demo/MainActivityTest.kt
@@ -552,8 +552,7 @@ class MainActivityTest {
             scope,
             { authToken ->
                 client.updatePassword(
-                    authToken,
-                    UpdatePasswordRequest.FreshAccessTokenParams(newPassword),
+                    UpdatePasswordRequest.FreshAccessTokenParams(authToken, newPassword),
                     successWithNoContent = {
                         client.loginWithPassword(
                             profile.email!!,
@@ -580,8 +579,7 @@ class MainActivityTest {
             scope,
             { authToken ->
                 client.updatePassword(
-                    authToken,
-                    UpdatePasswordRequest.AccessTokenParams(profile.password, newPassword),
+                    UpdatePasswordRequest.AccessTokenParams(authToken, profile.password, newPassword),
                     successWithNoContent = {
                         client.loginWithPassword(
                             profile.email!!,
@@ -607,8 +605,7 @@ class MainActivityTest {
             scope,
             { authToken ->
                 client.updatePassword(
-                    authToken,
-                    UpdatePasswordRequest.AccessTokenParams(profile.password, profile.password),
+                    UpdatePasswordRequest.AccessTokenParams(authToken, profile.password, profile.password),
                     successWithNoContent = { fail("This test should have failed because the password has not changed.") },
                     failure = { error ->
                         assertEquals(error.message, "Bad Request")
@@ -634,9 +631,8 @@ class MainActivityTest {
         client.signup(
             profile,
             scope,
-            { authToken ->
+            {
                 client.updatePassword(
-                    authToken,
                     UpdatePasswordRequest.EmailParams(profile.email!!, incorrectVerificationCode, "NEW-PASSWORD"),
                     successWithNoContent = { fail("This test should have failed because the verification code is incorrect.") },
                     failure = { error ->
@@ -659,9 +655,8 @@ class MainActivityTest {
         client.signup(
             profile,
             scope,
-            { authToken ->
+            {
                 client.updatePassword(
-                    authToken,
                     UpdatePasswordRequest.SmsParams(profile.phoneNumber!!, incorrectVerificationCode, "NEW-PASSWORD"),
                     successWithNoContent = { fail("This test should have failed because the verification code is incorrect.") },
                     failure = { error ->

--- a/sdk-core/src/main/java/com/reach5/identity/sdk/core/JavaReachFive.kt
+++ b/sdk-core/src/main/java/com/reach5/identity/sdk/core/JavaReachFive.kt
@@ -139,14 +139,12 @@ class JavaReachFive(activity: Activity, sdkConfig: SdkConfig, providersCreators:
     }
 
     fun updatePassword(
-        authToken: AuthToken,
-        updatePhoneNumberRequest: UpdatePasswordRequest,
+        updatePasswordRequest: UpdatePasswordRequest,
         successWithNoContent: Callback<Unit>,
         failure: Callback<ReachFiveError>
     ) {
         return reach5.updatePassword(
-            authToken,
-            updatePhoneNumberRequest,
+            updatePasswordRequest,
             { successWithNoContent.call(Unit) },
             failure::call
         )

--- a/sdk-core/src/main/java/com/reach5/identity/sdk/core/ReachFive.kt
+++ b/sdk-core/src/main/java/com/reach5/identity/sdk/core/ReachFive.kt
@@ -6,8 +6,9 @@ import android.util.Log
 import com.reach5.identity.sdk.core.api.ReachFiveApi
 import com.reach5.identity.sdk.core.api.ReachFiveApiCallback
 import com.reach5.identity.sdk.core.models.*
-import com.reach5.identity.sdk.core.models.requests.UpdatePasswordRequest.Companion.enrichWithClientId
 import com.reach5.identity.sdk.core.models.requests.*
+import com.reach5.identity.sdk.core.models.requests.UpdatePasswordRequest.Companion.enrichWithClientId
+import com.reach5.identity.sdk.core.models.requests.UpdatePasswordRequest.Companion.getAccessToken
 import com.reach5.identity.sdk.core.utils.Failure
 import com.reach5.identity.sdk.core.utils.Success
 import com.reach5.identity.sdk.core.utils.SuccessWithNoContent
@@ -196,15 +197,18 @@ class ReachFive(val activity: Activity, val sdkConfig: SdkConfig, val providersC
     }
 
     fun updatePassword(
-        authToken: AuthToken,
-        updatePhoneNumberRequest: UpdatePasswordRequest,
+        updatePasswordRequest: UpdatePasswordRequest,
         successWithNoContent: SuccessWithNoContent<Unit>,
         failure: Failure<ReachFiveError>
     ) {
+        val headers = getAccessToken(updatePasswordRequest)
+            ?.let { mapOf("Authorization" to formatAuthorization(it)) }
+            ?: emptyMap()
+
         reachFiveApi
             .updatePassword(
-                formatAuthorization(authToken),
-                enrichWithClientId(updatePhoneNumberRequest, sdkConfig.clientId),
+                headers,
+                enrichWithClientId(updatePasswordRequest, sdkConfig.clientId),
                 SdkInfos.getQueries()
             )
             .enqueue(ReachFiveApiCallback(successWithNoContent = successWithNoContent, failure = failure))

--- a/sdk-core/src/main/java/com/reach5/identity/sdk/core/api/ReachFiveApi.kt
+++ b/sdk-core/src/main/java/com/reach5/identity/sdk/core/api/ReachFiveApi.kt
@@ -75,7 +75,7 @@ interface ReachFiveApi {
 
     @POST("/identity/v1/update-password")
     fun updatePassword(
-        @Header("Authorization") authorization: String,
+        @HeaderMap headers: Map<String, String>,
         @Body updatePhoneNumberRequest: UpdatePasswordRequest,
         @QueryMap options: Map<String, String>
     ): Call<Unit>

--- a/sdk-core/src/main/java/com/reach5/identity/sdk/core/models/requests/UpdatePasswordRequest.kt
+++ b/sdk-core/src/main/java/com/reach5/identity/sdk/core/models/requests/UpdatePasswordRequest.kt
@@ -6,17 +6,21 @@ import com.google.gson.JsonElement
 import com.google.gson.JsonSerializationContext
 import com.google.gson.JsonSerializer
 import com.google.gson.annotations.SerializedName
+import com.reach5.identity.sdk.core.models.AuthToken
+import com.reach5.identity.sdk.core.models.ReachFiveError
 import kotlinx.android.parcel.Parcelize
 import java.lang.reflect.Type
 
 sealed class UpdatePasswordRequest {
     @Parcelize
     data class FreshAccessTokenParams(
+        val freshAuthToken: AuthToken,
         val password: String
     ) : UpdatePasswordRequest(), Parcelable
 
     @Parcelize
     data class AccessTokenParams(
+        val authToken: AuthToken,
         @SerializedName("old_password")
         val oldPassword: String,
         val password: String
@@ -30,7 +34,14 @@ sealed class UpdatePasswordRequest {
     ) : UpdatePasswordRequest(), Parcelable
 
     @Parcelize
-    data class EmailWithClientIdParams(
+    data class SmsParams(
+        val phoneNumber: String,
+        val verificationCode: String,
+        val password: String
+    ) : UpdatePasswordRequest(), Parcelable
+
+    @Parcelize
+    private data class EmailWithClientIdParams(
         val email: String,
         @SerializedName("verification_code")
         val verificationCode: String,
@@ -40,14 +51,7 @@ sealed class UpdatePasswordRequest {
     ) : UpdatePasswordRequest(), Parcelable
 
     @Parcelize
-    data class SmsParams(
-        val phoneNumber: String,
-        val verificationCode: String,
-        val password: String
-    ) : UpdatePasswordRequest(), Parcelable
-
-    @Parcelize
-    data class SmsWithClientIdParams(
+    private data class SmsWithClientIdParams(
         @SerializedName("phone_number")
         val phoneNumber: String,
         @SerializedName("verification_code")
@@ -75,6 +79,14 @@ sealed class UpdatePasswordRequest {
                         clientId
                     )
                 else -> params
+            }
+        }
+
+        fun <T : UpdatePasswordRequest> getAccessToken(params: T): AuthToken? {
+            return when(params) {
+                is FreshAccessTokenParams -> params.freshAuthToken
+                is AccessTokenParams -> params.authToken
+                else -> null
             }
         }
     }


### PR DESCRIPTION
Issue #39 

**Fixes**:
- The `authToken` argument of the `updatePassword` method is now optional since it's not required for all the password update use cases.
- I've renamed the `updatePhoneNumberRequest` argument to `updatePasswordRequest`.