### PR TITLE
Delete the `redirectUrl` argument from the `logout` method

### DIFF
--- a/app/src/main/java/com/reach5/identity/sdk/demo/JavaMainActivity.java
+++ b/app/src/main/java/com/reach5/identity/sdk/demo/JavaMainActivity.java
@@ -120,11 +120,10 @@ public class JavaMainActivity extends AppCompatActivity {
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case R.id.menu_logout:
-                reach5.logout(null,
-                        success -> showToast("Logout success"), failure -> {
-                            Log.d(TAG, "logout error=" + failure.getMessage());
-                            showToast("Logout Error " + failure.getMessage());
-                        });
+                reach5.logout(success -> showToast("Logout success"), failure -> {
+                    Log.d(TAG, "logout error=" + failure.getMessage());
+                    showToast("Logout Error " + failure.getMessage());
+                });
                 return true;
             case R.id.menu_java:
                 finish();

--- a/sdk-core/src/main/java/com/reach5/identity/sdk/core/JavaReachFive.kt
+++ b/sdk-core/src/main/java/com/reach5/identity/sdk/core/JavaReachFive.kt
@@ -79,11 +79,10 @@ class JavaReachFive(activity: Activity, sdkConfig: SdkConfig, providersCreators:
     }
 
     fun logout(
-        redirectTo: String? = null,
         successWithNoContent: Callback<Unit>,
         failure: Callback<ReachFiveError>
     ) {
-        return reach5.logout(redirectTo, { successWithNoContent.call(Unit) }, failure::call)
+        return reach5.logout({ successWithNoContent.call(Unit) }, failure::call)
     }
 
     fun getProfile(

--- a/sdk-core/src/main/java/com/reach5/identity/sdk/core/ReachFive.kt
+++ b/sdk-core/src/main/java/com/reach5/identity/sdk/core/ReachFive.kt
@@ -116,16 +116,13 @@ class ReachFive(val activity: Activity, val sdkConfig: SdkConfig, val providersC
     }
 
     fun logout(
-        redirectTo: String? = null,
         successWithNoContent: SuccessWithNoContent<Unit>,
         failure: Failure<ReachFiveError>
     ) {
         providers.forEach { it.logout() }
 
-        val queries = SdkInfos.getQueries()
-        val options = if (redirectTo != null) queries.plus(Pair("redirect_to", redirectTo)) else queries
         reachFiveApi
-            .logout(options)
+            .logout(SdkInfos.getQueries())
             .enqueue(ReachFiveApiCallback(successWithNoContent = successWithNoContent, failure = failure))
     }
 


### PR DESCRIPTION
I've removed the `redirectUrl` argument from the `logout` method since it's useless for mobile.