### PR TITLE
Delete the `code` parameter from `AuthToken` and `AuthTokenResponse`

### DIFF
--- a/sdk-core/src/main/java/com/reach5/identity/sdk/core/models/AuthTokenResponse.kt
+++ b/sdk-core/src/main/java/com/reach5/identity/sdk/core/models/AuthTokenResponse.kt
@@ -12,7 +12,6 @@ data class AuthToken(
     // If the `openid` scope is not provided, the `idToken` is not returned
     val idToken: String? = null,
     val accessToken: String,
-    val code: String?,
     val tokenType: String?,
     val expiresIn: Int?,
     // The `user` field is optional because if the `openid` scope is not provided, the `user` is not retrieved
@@ -26,9 +25,6 @@ data class AuthTokenResponse(
 
     @SerializedName("access_token")
     val accessToken: String? = null,
-
-    @SerializedName("code")
-    val code: String? = null,
 
     @SerializedName("token_type")
     val tokenType: String? = null,
@@ -49,7 +45,6 @@ data class AuthTokenResponse(
                     AuthToken(
                         idToken = idToken,
                         accessToken = accessToken,
-                        code = code,
                         tokenType = tokenType,
                         expiresIn = expiresIn,
                         user = it
@@ -59,7 +54,6 @@ data class AuthTokenResponse(
                 Result.of {
                     AuthToken(
                         accessToken = accessToken,
-                        code = code,
                         tokenType = tokenType,
                         expiresIn = expiresIn
                     )


### PR DESCRIPTION
I've removed the `code` parameter from the `AuthToken` and `AuthTokenResponse` models since it's useless.