### PR TITLE
Change the type of `consentType`

### DIFF
--- a/sdk-core/src/main/java/com/reach5/identity/sdk/core/models/Consent.kt
+++ b/sdk-core/src/main/java/com/reach5/identity/sdk/core/models/Consent.kt
@@ -8,6 +8,6 @@ import kotlinx.android.parcel.Parcelize
 data class Consent(
     val granted: Boolean,
     @SerializedName("consent_type")
-    val consentType: Boolean?,
+    val consentType: String?,
     val date: String
 ) : Parcelable


### PR DESCRIPTION
Issue #46 

The type of the `Consent.consentType` should be a `String` and not a `Boolean`.