### PR TITLE
Refresh Token minor improvements

### DIFF
--- a/app/src/androidTest/java/com/reach5/identity/sdk/demo/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/reach5/identity/sdk/demo/MainActivityTest.kt
@@ -21,7 +21,7 @@ import kotlin.random.Random
  * These tests use an account with:
  * - the SMS feature enabled
  * - the country set to "France"
- * - the following ENFORCED scope: ['email', 'full_write', 'openid', 'phone', 'profile']
+ * - the following ENFORCED scope: ['email', 'full_write', 'openid', 'phone', 'profile', 'offline_access"]
  */
 @RunWith(AndroidJUnit4::class)
 class MainActivityTest {

--- a/app/src/androidTest/java/com/reach5/identity/sdk/demo/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/reach5/identity/sdk/demo/MainActivityTest.kt
@@ -758,7 +758,7 @@ class MainActivityTest {
                 Thread.sleep(1000)
 
                 client.refreshAccessToken(
-                    refreshToken = authToken.refreshToken!!,
+                    authToken = authToken,
                     success = { newAuthToken ->
                         assertNotNull(newAuthToken.refreshToken)
                         assertNotEquals("Server should have generated a new access token", authToken.accessToken, newAuthToken.accessToken)

--- a/sdk-core/src/main/java/com/reach5/identity/sdk/core/JavaReachFive.kt
+++ b/sdk-core/src/main/java/com/reach5/identity/sdk/core/JavaReachFive.kt
@@ -6,8 +6,6 @@ import com.reach5.identity.sdk.core.models.*
 import com.reach5.identity.sdk.core.models.requests.ProfileSignupRequest
 import com.reach5.identity.sdk.core.models.requests.UpdatePasswordRequest
 import com.reach5.identity.sdk.core.utils.Callback
-import com.reach5.identity.sdk.core.utils.Failure
-import com.reach5.identity.sdk.core.utils.SuccessWithNoContent
 
 class JavaReachFive(activity: Activity, sdkConfig: SdkConfig, providersCreators: List<ProviderCreator>) {
     private val reach5 = ReachFive(activity, sdkConfig, providersCreators)
@@ -161,6 +159,18 @@ class JavaReachFive(activity: Activity, sdkConfig: SdkConfig, providersCreators:
             redirectUrl,
             phoneNumber,
             { successWithNoContent.call(Unit) },
+            failure::call
+        )
+    }
+
+    fun refreshAccessToken(
+        authToken: AuthToken,
+        success: Callback<AuthToken>,
+        failure: Callback<ReachFiveError>
+    ) {
+        return reach5.refreshAccessToken(
+            authToken,
+            success::call,
             failure::call
         )
     }

--- a/sdk-core/src/main/java/com/reach5/identity/sdk/core/ReachFive.kt
+++ b/sdk-core/src/main/java/com/reach5/identity/sdk/core/ReachFive.kt
@@ -127,13 +127,13 @@ class ReachFive(val activity: Activity, val sdkConfig: SdkConfig, val providersC
     }
 
     fun refreshAccessToken(
-        refreshToken: String,
+        authToken: AuthToken,
         success: Success<AuthToken>,
         failure: Failure<ReachFiveError>
     ) {
         val refreshRequest = RefreshRequest(
             clientId  = sdkConfig.clientId,
-            refreshToken = refreshToken,
+            refreshToken = authToken.refreshToken ?: "",
             redirectUri = SdkConfig.REDIRECT_URI
         )
 


### PR DESCRIPTION
* use `authToken: AuthToken` instead of `refreshToken: String` in `refreshAccessToken`
* add `refreshAccessToken` to `JavaReachFive`