### PR TITLE
Release v5.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v5.3.1 (23/08/2019)
+
+### Fixes
+
+- The `ProfileAddress` model's `isDefault` attribute is now correctly serialized.
+- All the string attributes of the `ProfileAddress` model are now null by default.
+- The `addressType` attribute of the `ProfileAddress` model is no longer a `String` but a `ProfileAddressType`.
+
 ## v5.3.0 (22/08/2019)
 
 ### Features

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext.kotlin_version = "1.3.41"
-    ext.lib_version = "5.3.0"
+    ext.lib_version = "5.3.1"
     ext.lib_group = "com.reach5.identity"
     ext.min_sdk_version = 19
     ext.target_sdk_version = 28


### PR DESCRIPTION
- Update the changelog.
- Bump the version to `5.3.1`.