### PR TITLE
Return the custom fields when the profile is fetched

### DIFF
--- a/app/src/androidTest/java/com/reach5/identity/sdk/demo/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/reach5/identity/sdk/demo/MainActivityTest.kt
@@ -208,7 +208,6 @@ class MainActivityTest {
         )
     }
 
-
     @Test
     fun testFailedSignupWeakPassword() = clientTest { client, passTest ->
         val weakPassword = "toto"
@@ -324,6 +323,36 @@ class MainActivityTest {
                         passTest()
                     },
                     { error -> failWithReachFiveError(error) }
+                )
+            },
+            failure = { failWithReachFiveError(it) }
+        )
+    }
+
+    @Test
+    fun testSuccessfulGetProfileWithCustomFields() = clientTest { client, passTest ->
+        val customFields = mapOf<String, Any>(
+            Pair("test_string", "toto"),
+            Pair("mobile_number1", "0678236342")
+        )
+        val theProfile = aProfile().copy(customFields = customFields)
+        val scope = openId + email + profile
+
+        client.signup(
+            theProfile,
+            scope = scope,
+            success = { authToken ->
+                assertNotNull(authToken)
+
+                client.getProfile(
+                    authToken,
+                    success = {
+                        assertNotNull(it.customFields)
+                        assertEquals(customFields["test_string"], it.customFields?.get("test_string"))
+                        assertEquals(customFields["mobile_number1"], it.customFields?.get("mobile_number1"))
+                        passTest()
+                    },
+                    failure = { failWithReachFiveError(it) }
                 )
             },
             failure = { failWithReachFiveError(it) }

--- a/app/src/androidTest/java/com/reach5/identity/sdk/demo/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/reach5/identity/sdk/demo/MainActivityTest.kt
@@ -333,7 +333,7 @@ class MainActivityTest {
     fun testSuccessfulGetProfileWithCustomFields() = clientTest { client, passTest ->
         val customFields = mapOf<String, Any>(
             Pair("test_string", "toto"),
-            Pair("mobile_number1", "0678236342")
+            Pair("mobile_number1", aPhoneNumber())
         )
         val theProfile = aProfile().copy(customFields = customFields)
         val scope = openId + email + profile

--- a/sdk-core/src/main/java/com/reach5/identity/sdk/core/ReachFive.kt
+++ b/sdk-core/src/main/java/com/reach5/identity/sdk/core/ReachFive.kt
@@ -193,8 +193,9 @@ class ReachFive(
         success: Success<Profile>,
         failure: Failure<ReachFiveError>
     ) {
+        val fields = "addresses,auth_types,created_at,custom_fields,devices,email,family_name,first_login,first_name,full_name,gender,given_name,has_managed_profile,has_password,id,identities,last_login,last_login_provider,last_login_type,last_name,likes_friends_ratio,lite_only,local_friends_count,login_summary,logins_count,name,origins,provider_details,providers,social_identities,sub,uid,updated_at"
         reachFiveApi
-            .getProfile(formatAuthorization(authToken), SdkInfos.getQueries())
+            .getProfile(formatAuthorization(authToken), SdkInfos.getQueries().plus(Pair("fields", fields)))
             .enqueue(ReachFiveApiCallback(success = success, failure = failure))
     }
 


### PR DESCRIPTION
Issue #48 

I've specified all the profile's fields in the `getProfile` endpoint URL, otherwise, the custom fields are not returned.