### PR TITLE
Release v5.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v5.4.2 (26/09/2019)
+
+### Fixes
+
+The custom fields are now returned by the [`getProfile`](https://developer.reach5.co/api/identity-android/#get-profile) method.
+
 ## v5.4.1 (23/09/2019)
 
 ### Changes

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext.kotlin_version = "1.3.41"
-    ext.lib_version = "5.4.1"
+    ext.lib_version = "5.4.2"
     ext.lib_group = "com.reach5.identity"
     ext.min_sdk_version = 19
     ext.target_sdk_version = 28


### PR DESCRIPTION
- Update the changelog.
- Bump the version to `5.4.2`.