### PR TITLE
Release v5.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v5.4.4 (08/11/2019)
+
+### Fixes
+
+The following fields are now returned by the [`getProfile`](https://developer.reach5.co/api/identity-android/#get-profile) method: `bio`, `birthdate`, `company`, `external_id`, `locale`, `middle_name`, `nickname`, `picture` and `tos_accepted_at`.
+
 ## v5.4.3 (27/09/2019)
 
 ### Fixes

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext.kotlin_version = "1.3.41"
-    ext.lib_version = "5.4.3"
+    ext.lib_version = "5.4.4"
     ext.lib_group = "com.reach5.identity"
     ext.min_sdk_version = 19
     ext.target_sdk_version = 28


### PR DESCRIPTION
- Update the changelog.
- Bump the version to `v5.4.4`.