### PR TITLE
Fix the Webview login

### DIFF
--- a/app/src/main/java/com/reach5/identity/sdk/demo/MainActivity.kt
+++ b/app/src/main/java/com/reach5/identity/sdk/demo/MainActivity.kt
@@ -19,6 +19,7 @@ import com.reach5.identity.sdk.demo.AuthenticatedActivity.Companion.AUTH_TOKEN
 import com.reach5.identity.sdk.demo.AuthenticatedActivity.Companion.SDK_CONFIG
 import com.reach5.identity.sdk.facebook.FacebookProvider
 import com.reach5.identity.sdk.google.GoogleProvider
+import com.reach5.identity.sdk.webview.ConfiguredWebViewProvider.Companion.PROVIDER_REDIRECTION_REQUEST_CODE
 import com.reach5.identity.sdk.webview.WebViewProvider
 import io.github.cdimascio.dotenv.dotenv
 import kotlinx.android.synthetic.main.activity_main.*
@@ -276,8 +277,7 @@ class MainActivity : AppCompatActivity() {
                 else handleLoginCallbackResponse(data, resultCode)
             }
 
-            // Handle provider login
-            else -> {
+            PROVIDER_REDIRECTION_REQUEST_CODE -> {
                 this.reach5.onActivityResult(
                     requestCode = requestCode,
                     resultCode = resultCode,
@@ -289,6 +289,11 @@ class MainActivity : AppCompatActivity() {
                         showErrorToast(error)
                     }
                 )
+            }
+
+            else -> {
+                Log.d(TAG, "onActivityResult Operation failed with unknown request code")
+                showToast("Operation failed")
             }
         }
     }

--- a/app/src/main/res/values/settings.xml
+++ b/app/src/main/res/values/settings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="facebook_app_id">2326266780745811</string>
-    <string name="facebook_login_protocol_scheme">fb2326266780745811</string>
+    <string name="fb_login_protocol_scheme">fb2326266780745811</string>
     <string name="reachfive_scheme">reachfive-lscdhbotrpeh8rflz6bb</string>
 </resources>

--- a/sdk-webview/src/main/java/com/reach5/identity/sdk/webview/ReachFiveLoginActivity.kt
+++ b/sdk-webview/src/main/java/com/reach5/identity/sdk/webview/ReachFiveLoginActivity.kt
@@ -55,13 +55,13 @@ class ReachFiveLoginActivity : Activity() {
             ConfiguredWebViewProvider.RESULT_INTENT_ERROR,
             message
         )
-        setResult(ConfiguredWebViewProvider.RequestCode, intent)
+        setResult(ConfiguredWebViewProvider.PROVIDER_REDIRECTION_REQUEST_CODE, intent)
         finish()
     }
 
     fun loginSuccess(authCode: String?) {
         intent.putExtra(ConfiguredWebViewProvider.AuthCode, authCode)
-        setResult(ConfiguredWebViewProvider.RequestCode, intent)
+        setResult(ConfiguredWebViewProvider.PROVIDER_REDIRECTION_REQUEST_CODE, intent)
         finish()
     }
 

--- a/sdk-webview/src/main/java/com/reach5/identity/sdk/webview/WebViewProvider.kt
+++ b/sdk-webview/src/main/java/com/reach5/identity/sdk/webview/WebViewProvider.kt
@@ -6,7 +6,10 @@ import com.reach5.identity.sdk.core.Provider
 import com.reach5.identity.sdk.core.ProviderCreator
 import com.reach5.identity.sdk.core.api.ReachFiveApi
 import com.reach5.identity.sdk.core.api.ReachFiveApiCallback
-import com.reach5.identity.sdk.core.models.*
+import com.reach5.identity.sdk.core.models.ProviderConfig
+import com.reach5.identity.sdk.core.models.ReachFiveError
+import com.reach5.identity.sdk.core.models.SdkConfig
+import com.reach5.identity.sdk.core.models.SdkInfos
 import com.reach5.identity.sdk.core.models.requests.AuthCodeRequest
 import com.reach5.identity.sdk.core.models.responses.AuthToken
 import com.reach5.identity.sdk.core.utils.Failure
@@ -33,13 +36,13 @@ class ConfiguredWebViewProvider(
 ) : Provider {
 
     override val name: String = providerConfig.provider
-    override val requestCode: Int = RequestCode
+    override val requestCode: Int = PROVIDER_REDIRECTION_REQUEST_CODE
 
     companion object {
         const val BUNDLE_ID = "BUNDLE_REACH_FIVE"
         const val AuthCode = "AuthCode"
         const val PKCE = "PKCE"
-        const val RequestCode = 52558
+        const val PROVIDER_REDIRECTION_REQUEST_CODE = 52559
         const val RESULT_INTENT_ERROR = "RESULT_INTENT_ERROR"
     }
 


### PR DESCRIPTION
The **Webview** redirection request code and the **Custom tab** redirection requests code were the same, so the Facebook login was not working anymore (the exchange of the auth code with the access token was never made).