### PR TITLE
Don't specify the ReachFive origin domain in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ DOMAIN=my-reachfive-url
 CLIENT_ID=my-reachfive-client-id
 SCHEME=my-reachfive-url-scheme
 
-ORIGIN=https://dev-sandbox-268508.web.app
+ORIGIN=my-webauthn-origin-domain
 ```
 
 ## Documentation


### PR DESCRIPTION
The ReachFive origin domain used for Webauthn will be documented in the ReachFive Slite project.