### PR TITLE
Change the launch mode of the `RedirectionActivity` activity

### DIFF
--- a/sdk-core/src/main/AndroidManifest.xml
+++ b/sdk-core/src/main/AndroidManifest.xml
@@ -5,6 +5,6 @@
     <application>
         <activity
                 android:name=".RedirectionActivity"
-                android:launchMode="singleTop"/>
+                android:launchMode="singleTask"/>
     </application>
 </manifest>


### PR DESCRIPTION
The Webauth flow wasn't working on some devices: the `RedirectionActivity` activity was recreated so the `code` couldn't be parsed by the `onNewIntent` method. I've updated the `launchmode` of the activity to `singleTask` so that the activity is not recreated if it already exists.