### PR TITLE
Add ProGuard rules for network model classes

### DIFF
--- a/sdk-core/build.gradle
+++ b/sdk-core/build.gradle
@@ -19,6 +19,7 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
+            consumerProguardFiles 'proguard-rules.pro'
         }
     }
 

--- a/sdk-core/proguard-rules.pro
+++ b/sdk-core/proguard-rules.pro
@@ -19,3 +19,6 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+### Avoid network model classes to be obfuscated
+-keep class com.reach5.identity.sdk.core.models.** {*;}


### PR DESCRIPTION
**Scenario:**
SDK used in an App which uses ProGuard/R8 for obfuscation in a Release build.

**Expected:** 
Everything should work as in a Debug build.

**Actual:**
App crashes due to an NPE on `clientConfig` which is not correctly parsed by the SDK because the JSON/dataClass mapping fails because network model data classes were obfuscated by ProGuard.
[Here the link to where the NPE happens
](https://github.com/ReachFive/identity-android-sdk/blob/9ac15e09e779902ba8682fd75692c9c83e2d6a32/sdk-core/src/main/java/com/reach5/identity/sdk/core/ReachFive.kt#L59)

**PR explanation:**
This PR adds a rule to avoid network model classes be obfuscated by ProGuard to achieve the expected scenario.