### PR TITLE
Release v6.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v6.2.1 (20/09/2021)
+
+### Changes
+
+- Publish artifacts to Sonatype
+- Package FQDN has changed from `com.reach5.identity` to `co.reachfive.identity`
+
 ## v6.2.0 (10/09/2021)
 
 ### Changes


### PR DESCRIPTION
# Sonatype migration

This release contains no actual changes aside from a revised publication target for SDK artifacts which are now uploaded to Sonatype instead of Bintray. The SDK can therefore now be resolved via Maven Central, albeit under a new FQDN: `co.reachfive`. 

⚠️  To prevent breaking changes, this release does not yet change package names. A future release will update package names to `co.reachfive`, which will require you to update your project accordingly!