### PR TITLE
[CA-1221] Use configured identity client scope as default value in SLO flows

### DIFF
--- a/sdk-core/src/main/java/co/reachfive/identity/sdk/core/ReachFive.kt
+++ b/sdk-core/src/main/java/co/reachfive/identity/sdk/core/ReachFive.kt
@@ -114,7 +114,7 @@ class ReachFive(
 
     fun loginWithProvider(
         name: String,
-        scope: Collection<String> = emptySet(),
+        scope: Collection<String> = this.scope,
         origin: String,
         activity: Activity
     ) {


### PR DESCRIPTION
With the exception of `loginWithProvider`, by default, all login methods use the identity client's configured scope. This PR aligns `loginWithProvider`'s behavior with the others.