### PR TITLE
Get SDK version from a single source

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,7 @@ subprojects {
             targetSdkVersion androidSettings.target_sdk_version
             versionCode androidSettings.version_code
             versionName this.version
+            buildConfigField("String", "r5_sdk_version", "\"$libversion\"")
         }
 
         buildTypes {

--- a/libversion.gradle
+++ b/libversion.gradle
@@ -1,1 +1,1 @@
-ext.libversion="7.0.0"
+ext.libversion="7.0.1"

--- a/sdk-core/src/main/java/co/reachfive/identity/sdk/core/models/SdkInfos.kt
+++ b/sdk-core/src/main/java/co/reachfive/identity/sdk/core/models/SdkInfos.kt
@@ -1,9 +1,10 @@
 package co.reachfive.identity.sdk.core.models
 
 import android.os.Build
+import co.reachfive.identity.sdk.core.BuildConfig
 
 object SdkInfos {
-    const val version = "4.0.0"
+    val version = BuildConfig.r5_sdk_version
     private const val platform = "android"
     private val device: String = Build.DEVICE
     private val model: String = Build.MODEL


### PR DESCRIPTION
Fetch the SDK version from the build rather than use a hardcoded string.