### PR TITLE
Reinstate deprecated method

### DIFF
--- a/sdk-core/src/main/java/co/reachfive/identity/sdk/core/SessionUtils.kt
+++ b/sdk-core/src/main/java/co/reachfive/identity/sdk/core/SessionUtils.kt
@@ -88,6 +88,7 @@ class SessionUtilsClient(
         }
     }
 
+    @Deprecated("Contact ReachFive support if you are using this method.")
     override fun exchangeCodeForToken(
         authorizationCode: String,
         success: Success<AuthToken>,

--- a/sdk-core/src/main/java/co/reachfive/identity/sdk/core/SessionUtils.kt
+++ b/sdk-core/src/main/java/co/reachfive/identity/sdk/core/SessionUtils.kt
@@ -34,7 +34,7 @@ internal interface SessionUtils {
         activity: Activity,
     )
 
-    @Deprecated("")
+    @Deprecated("Contact ReachFive support if you are using this method.")
     fun exchangeCodeForToken(
         authorizationCode: String,
         success: Success<AuthToken>,

--- a/sdk-core/src/main/java/co/reachfive/identity/sdk/core/SessionUtils.kt
+++ b/sdk-core/src/main/java/co/reachfive/identity/sdk/core/SessionUtils.kt
@@ -206,7 +206,14 @@ class SessionUtilsClient(
             redirectUri = redirectUri,
             scope = scope,
             success = { authCode ->
-                exchangeAuthorizationCode(authCode, pkce.codeVerifier, success, failure)
+                exchangeAuthorizationCode(
+                    authCode,
+                    redirectUri,
+                    pkce.codeVerifier,
+                    success,
+                    failure,
+                    sdkMethod = "loginCallback"
+                )
             },
             failure = failure
         )

--- a/sdk-core/src/main/java/co/reachfive/identity/sdk/core/models/ErrorCode.kt
+++ b/sdk-core/src/main/java/co/reachfive/identity/sdk/core/models/ErrorCode.kt
@@ -24,5 +24,6 @@ enum class ErrorCode(val code: Int) {
      */
     WebFlowCanceled(52001),
     NullIntent(52002),
-    NoAuthCode(52003);
+    NoAuthCode(52003),
+    NoPkce(52004);
 }

--- a/sdk-core/src/main/java/co/reachfive/identity/sdk/core/models/ReachFiveError.kt
+++ b/sdk-core/src/main/java/co/reachfive/identity/sdk/core/models/ReachFiveError.kt
@@ -137,9 +137,9 @@ data class ReachFiveError(
         )
 
         @JvmStatic
-        val NoPkce = ReachFiveError(
+        val NoAuthCode = ReachFiveError(
             code = ErrorCode.NoPkce.code,
-            message = "No PKCE code_verifier could be found when expected."
+            message = "No authorization code could be found when expected."
         )
 
         @JvmStatic

--- a/sdk-core/src/main/java/co/reachfive/identity/sdk/core/models/ReachFiveError.kt
+++ b/sdk-core/src/main/java/co/reachfive/identity/sdk/core/models/ReachFiveError.kt
@@ -111,9 +111,9 @@ data class ReachFiveError(
         )
 
         @JvmStatic
-        val NoAuthCode = ReachFiveError(
-            code = ErrorCode.NoAuthCode.code,
-            message = "No authorization code could be found when expected."
+        val NoPkce = ReachFiveError(
+            code = ErrorCode.NoPkce.code,
+            message = "No PKCE code_verifier could be found when expected."
         )
     }
 }

--- a/sdk-core/src/main/java/co/reachfive/identity/sdk/core/models/SdkInfos.kt
+++ b/sdk-core/src/main/java/co/reachfive/identity/sdk/core/models/SdkInfos.kt
@@ -15,11 +15,12 @@ object SdkInfos {
         return "API Level $apiLevel, Device $device, Model $model, Product $product"
     }
 
-    fun getQueries(): Map<String, String> {
+    fun getQueries(sdkMethod: String? = null): Map<String, String> {
+        val method = if (sdkMethod != null) mapOf("sdk_method" to sdkMethod) else emptyMap()
         return mapOf(
             "platform" to platform,
             "device" to deviceInfo(),
-            "version" to version
-        )
+            "version" to version,
+        ) + method
     }
 }


### PR DESCRIPTION
We don't have complete visibility over how this method is used by integrators (i.e., custom implementations). To prevent blocking such potential integrations, reinstate the deprecated method `exchangeCodeForToken`.