### PR TITLE
fix(intent_redirect): secure intent redirect with expected package name

### DIFF
--- a/sdk-core/src/main/java/co/reachfive/identity/sdk/core/RedirectionActivity.kt
+++ b/sdk-core/src/main/java/co/reachfive/identity/sdk/core/RedirectionActivity.kt
@@ -41,11 +41,14 @@ class RedirectionActivity : Activity() {
         newIntent.flags = 0
 
         val intentClass = newIntent.resolveActivity(packageManager).className
-        val scheme = intent.getStringExtra(SCHEME) ?: "???"
+        val scheme = intent.getStringExtra(SCHEME)
         val url = newIntent.data
 
+        val packageName = this.callingActivity?.packageName
+        val expectedPackageName = applicationContext.packageName
+
         // ensure intent target && URL belong to us
-        if (intentClass == FQN && url.toString().startsWith(scheme)) {
+        if (intentClass == FQN && packageName == expectedPackageName && scheme != null && url.toString().startsWith(scheme)) {
             intent.data = url
             setResult(Activity.RESULT_OK, intent)
         } else {


### PR DESCRIPTION
Since the end of last month, Google declined our app on the Play Store as it's _vulnerable to Intent Redirection_ with the method `co.reachfive.identity.sdk.core.RedirectionActivity.onNewIntent`.

This PR try to prevent the vulnerability another way than it's done today as the upgrade to the `8.1.1` version didn't change anything in Google's warnings about this vulnerability.

As specified in [Google documentation](https://support.google.com/faqs/answer/9267555), we should _Ensure that the extracted Intent is from a trustworthy source_. In this PR, we check if the originating Activity is from trusted package, getting it from the `applicationContext`, matching the **Option 2** of 3 from the above link.