### PR TITLE
[CA-2691] Fix intent vulnerability

### DIFF
--- a/libversion.gradle
+++ b/libversion.gradle
@@ -1,1 +1,1 @@
-ext.libversion = "8.1.1"
+ext.libversion = "8.1.2"

--- a/sdk-core/src/main/java/co/reachfive/identity/sdk/core/RedirectionActivity.kt
+++ b/sdk-core/src/main/java/co/reachfive/identity/sdk/core/RedirectionActivity.kt
@@ -41,11 +41,14 @@ class RedirectionActivity : Activity() {
         newIntent.flags = 0
 
         val intentClass = newIntent.resolveActivity(packageManager).className
-        val scheme = intent.getStringExtra(SCHEME) ?: "???"
+        val scheme = intent.getStringExtra(SCHEME)
         val url = newIntent.data
 
+        val packageName = this.callingActivity?.packageName
+        val expectedPackageName = applicationContext.packageName
+
         // ensure intent target && URL belong to us
-        if (intentClass == FQN && url.toString().startsWith(scheme)) {
+        if (intentClass == FQN && packageName == expectedPackageName && scheme != null && url.toString().startsWith(scheme)) {
             intent.data = url
             setResult(Activity.RESULT_OK, intent)
         } else {

--- a/sdk-core/src/main/java/co/reachfive/identity/sdk/core/RedirectionActivity.kt
+++ b/sdk-core/src/main/java/co/reachfive/identity/sdk/core/RedirectionActivity.kt
@@ -41,19 +41,27 @@ class RedirectionActivity : Activity() {
         newIntent.flags = 0
 
         val intentClass = newIntent.resolveActivity(packageManager).className
+
         val scheme = intent.getStringExtra(SCHEME)
         val url = newIntent.data
+        val isTargetR5 = intentClass == FQN && scheme != null && url.toString().startsWith(scheme)
+        if (!isTargetR5) {
+            Log.e(TAG, "Unrecognized intent class: $intentClass")
+        }
 
-        val packageName = this.callingActivity?.packageName
-        val expectedPackageName = applicationContext.packageName
+        val callingPackageName = this.callingActivity?.packageName
+        val isTrustedCaller =
+            callingPackageName != null && callingPackageName == applicationContext.packageName
+        if (!isTrustedCaller) {
+            Log.e(TAG, "Unrecognized calling activity: ${callingPackageName ?: "N/A"}")
+        }
 
         // ensure intent target && URL belong to us
-        if (intentClass == FQN && packageName == expectedPackageName && scheme != null && url.toString().startsWith(scheme)) {
+        if (isTargetR5 && isTrustedCaller) {
             intent.data = url
-            setResult(Activity.RESULT_OK, intent)
+            setResult(RESULT_OK, intent)
         } else {
-            Log.e(TAG, "Unrecognized intent!")
-            setResult(Activity.RESULT_CANCELED)
+            setResult(RESULT_CANCELED)
         }
 
         finish()


### PR DESCRIPTION
#173 seems to not have resolved the intent redirection vulnerability warning for some customers. This PR adds simple refactors on top of #175 which implements option 2 of Google's [mitigation document](https://support.google.com/faqs/answer/9267555).