### PR TITLE
[CA-4669] Set cookie returned by verify passwordless when device is trusted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
  
 ## Unreleased
+- trusted device cookie is set during verify passwordless when trust device is true
 
 ## v9.6.0 (04/03/2025)
 

--- a/sdk-core/src/main/java/co/reachfive/identity/sdk/core/api/ReachFiveApi.kt
+++ b/sdk-core/src/main/java/co/reachfive/identity/sdk/core/api/ReachFiveApi.kt
@@ -275,6 +275,7 @@ interface ReachFiveApi {
                 .addInterceptor(logging)
                 .addInterceptor(SessionCookieInterceptor(config.domain))
                 .addInterceptor(LogoutCookieInterceptor(config.domain))
+                .addInterceptor(TrustedDeviceCookieInterceptor(config.domain))
                 .addNetworkInterceptor(AcceptLanguageInterceptor())
                 .build()
 

--- a/sdk-core/src/main/java/co/reachfive/identity/sdk/core/api/SessionCookieInterceptor.kt
+++ b/sdk-core/src/main/java/co/reachfive/identity/sdk/core/api/SessionCookieInterceptor.kt
@@ -14,8 +14,9 @@ class SessionCookieInterceptor(private val domain: String) : Interceptor {
         val url =  chain.request().url.toString()
         val isTokenEndpoint = url.startsWith("https://$domain/oauth/token")
         val isLogoutEndpoint = url.startsWith("https://$domain/identity/v1/logout")
+        val isVerifyPasswordless = url.startsWith("https://$domain/identity/v1/passwordless/verify")
 
-        if (isTokenEndpoint || isLogoutEndpoint)
+        if (isTokenEndpoint || isLogoutEndpoint || isVerifyPasswordless)
             CookieManager.getInstance()?.let { cm ->
                 response.headers("Set-Cookie").forEach { cookie ->
                     Log.d(TAG, "set cookie")

--- a/sdk-core/src/main/java/co/reachfive/identity/sdk/core/api/TrustedDeviceCookieInterceptor.kt
+++ b/sdk-core/src/main/java/co/reachfive/identity/sdk/core/api/TrustedDeviceCookieInterceptor.kt
@@ -1,0 +1,25 @@
+package co.reachfive.identity.sdk.core.api
+
+import android.webkit.CookieManager
+import okhttp3.Interceptor
+import okhttp3.Response
+
+class TrustedDeviceCookieInterceptor(private val domain: String) : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val req = chain.request().newBuilder()
+
+        val url =  chain.request().url.toString()
+        val isLoginUrl = url.startsWith("https://$domain/identity/v1/password/login")
+
+        if (isLoginUrl)
+            CookieManager.getInstance()?.let { cm ->
+                val cookies = cm.getCookie("https://$domain")?.split("; ") ?: emptyList()
+                cookies.forEach {
+                    req.addHeader("Cookie", it)
+                }
+            }
+
+        return chain.proceed(req.build())
+    }
+}


### PR DESCRIPTION
This PR:
- sets cookie returned by verify passwordless when trustDevice is set to true
- forwards the trusted device cookie during password login call