### PR TITLE
[CA-5313] Change return type during signup when identifier is not verified and option forbidUnverifiedIdentifierLoginAfterSignup is enabled

### DIFF
--- a/libversion.gradle
+++ b/libversion.gradle
@@ -1,1 +1,1 @@
-ext.libversion = "9.9.2-develop"
+ext.libversion = "9.9.1"

--- a/libversion.gradle
+++ b/libversion.gradle
@@ -1,1 +1,1 @@
-ext.libversion = "9.9.1"
+ext.libversion = "9.9.2-develop"

--- a/sdk-core/src/main/java/co/reachfive/identity/sdk/core/JavaReachFive.kt
+++ b/sdk-core/src/main/java/co/reachfive/identity/sdk/core/JavaReachFive.kt
@@ -12,6 +12,7 @@ import co.reachfive.identity.sdk.core.models.requests.ProfileSignupRequest
 import co.reachfive.identity.sdk.core.models.requests.ProfileWebAuthnSignupRequest
 import co.reachfive.identity.sdk.core.models.requests.UpdatePasswordRequest
 import co.reachfive.identity.sdk.core.models.requests.webAuthn.WebAuthnLoginRequest
+import co.reachfive.identity.sdk.core.models.responses.SignupResponse
 import co.reachfive.identity.sdk.core.utils.Callback
 
 class JavaReachFive(
@@ -72,7 +73,7 @@ class JavaReachFive(
         profile: ProfileSignupRequest,
         scope: Collection<String>,
         redirectUrl: String? = null,
-        success: Callback<AuthToken>,
+        success: Callback<SignupResponse>,
         failure: Callback<ReachFiveError>,
         origin: String? = null
     ) {
@@ -84,7 +85,7 @@ class JavaReachFive(
      */
     fun signup(
         profile: ProfileSignupRequest,
-        success: Callback<AuthToken>,
+        success: Callback<SignupResponse>,
         failure: Callback<ReachFiveError>,
         origin: String? = null
     ) {

--- a/sdk-core/src/main/java/co/reachfive/identity/sdk/core/models/responses/SignupResponse.kt
+++ b/sdk-core/src/main/java/co/reachfive/identity/sdk/core/models/responses/SignupResponse.kt
@@ -1,0 +1,8 @@
+package co.reachfive.identity.sdk.core.models.responses
+
+import co.reachfive.identity.sdk.core.models.AuthToken
+
+sealed class SignupResponse {
+    data class AchievedLogin(val authToken: AuthToken): SignupResponse()
+    object AwaitingIdentifierVerification : SignupResponse()
+}


### PR DESCRIPTION
https://reach5.atlassian.net/browse/CA-5313